### PR TITLE
Include parent_station for id processing

### DIFF
--- a/R/merge_gtfs.R
+++ b/R/merge_gtfs.R
@@ -158,10 +158,13 @@ merge_gtfs <- function(..., files = NULL, prefix = FALSE) {
       # changed.
       # field_value, from translations, doesn't end with _id but refers to an
       # id, thus should be changed.
+      # parent_station, from stops, also doesn't end with _id but refers to an
+      # id (stops$stop_id), thus should also be changed.
 
       id_cols <- names(dt)[(grepl("_id$", names(dt)))]
       id_cols <- setdiff(id_cols, "direction_id")
       if (!is.null(dt[["field_value"]])) id_cols <- c(id_cols, "field_value")
+      if (!is.null(dt[["parent_station"]])) id_cols <- c(id_cols, "parent_station")
 
       # then add the prefix to the id value
 


### PR DESCRIPTION
Add 'parent_station' to id_cols for processing.

I'm a working on a personal project, and I realized that gtfs_merge as it has been causing issues with foreign key violations in gtfs validator because it didn't include parent_station for the list of IDs it prefixes. stops$parent_station refers to another stop$stop_id within stops.txt, so it only makes sense it should also be prefixed.