### PR TITLE
Refactor character column identification in merge_gtfs to avoid run failures

### DIFF
--- a/R/merge_gtfs.R
+++ b/R/merge_gtfs.R
@@ -130,8 +130,7 @@ merge_gtfs <- function(..., files = NULL, prefix = FALSE) {
   for (dt in seq_along(merged_gtfs)) {
     # determine the character columns in each data.table
 
-    col_classes <- vapply(merged_gtfs[[dt]], class, character(1))
-    charac_cols <- which(col_classes == "character")
+    charac_cols <- which(vapply(merged_gtfs[[dt]], is.character, logical(1)))
 
     # then substitute NA by ""
 


### PR DESCRIPTION
<img width="730" height="218" alt="image" src="https://github.com/user-attachments/assets/9b7833d3-4d7b-4a97-9d45-b6909dc2bec2" />

`vapply(merged_gtfs[[dt]], class, character(1))` line is leading the code to break when there are columns that are not of type character (unknown). With the simplification I propose in this PR, the identification of those columns is more robust, avoiding these conflicts when there are other column types in the GTFS tables.

https://github.com/ipea/gtfstools/blob/27f862e19cb66cba8b7f283473a545d22099b8b2/R/merge_gtfs.R#L133-L134