### PR TITLE
Fixed missing prefix on stops.txt$parent_station on merge_gtfs() method

### DIFF
--- a/R/merge_gtfs.R
+++ b/R/merge_gtfs.R
@@ -158,7 +158,7 @@ merge_gtfs <- function(..., files = NULL, prefix = FALSE) {
       # field_value, from translations, doesn't end with _id but refers to an
       # id, thus should be changed.
 
-      id_cols <- names(dt)[(grepl("_id$", names(dt)))]
+      id_cols <- names(dt)[grepl("_id$|parent_station", names(dt))]
       id_cols <- setdiff(id_cols, "direction_id")
       if (!is.null(dt[["field_value"]])) id_cols <- c(id_cols, "field_value")
 


### PR DESCRIPTION
According to [GTFS official documentation](https://gtfs.org/documentation/schedule/reference/#stopstxt), stops.txt has a column `parent_station` that references a `stops.txt$stop_id`. However, the method `gtfstools::merge_gtfs()` only considers the columns that end with `_id` when applying the `prefix` parameter, which is generating an invalid `parent_station` column in the merged GTFS when this column exists.

https://github.com/ipea/gtfstools/blob/6bb51d8699927883730a5902c0f374954db31e0a/R/merge_gtfs.R#L161

<img width="1390" height="393" alt="image" src="https://github.com/user-attachments/assets/b4e63462-6a78-41b7-82e5-8cbbe91f257e" />

> GTFS documentation for stops.txt `parent_station` column

<img width="985" height="258" alt="image" src="https://github.com/user-attachments/assets/0bf4c529-abbc-4b58-a503-608554f39c00" />

> Example of output for TCB GTFS (https://backend.tcbarreiro.pt/download-gtfs) with a `prefix` equal to the `agency_id`, where we can see that only the `stop_id` was changed, while the `parent_station` remain unchanged.

With a simple refactoring to include `parent_station` in the `id_cols` filter fixes this.